### PR TITLE
Corrections

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,6 +1,6 @@
 import gulp from 'gulp';
 import gulpHelpers from 'gulp-helpers';
-import Builder from 'systemjs-builder';
+import {Builder} from 'jspm';
 
 let taskMaker = gulpHelpers.taskMaker(gulp);
 let situation = gulpHelpers.situation();
@@ -30,19 +30,7 @@ let path = {
 
 let bundler = (app) => {
 	let builder = new Builder();
-
-	return builder.loadConfig('src/main/config.js').then(function() {
-		builder.config(
-			{
-				paths: {
-					'github:*': './jspm_packages/github/*',
-					'npm:*': './jspm_packages/npm/*'
-				}
-			}
-		);
-		return builder.buildSFX(`js/${app}/app`, `${path.war}/js/${app}/${app}-bundle.js`,
-			{minify: false, sourceMaps: true});
-	});
+	return builder.buildSFX(`js/${app}/app`, `${path.war}/js/${app}/${app}-bundle.js`, {minify: false, sourceMaps: true});
 };
 
 taskMaker.defineTask('clean', {taskName: 'clean', src: path.output});

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   },
   "jspm": {
     "directories": {
-      "baseURL": "src/main",
-      "packages": "jspm_packages"
+      "baseURL": "src/main"
     },
     "dependencies": {
       "angular": "github:angular/bower-angular@^1.4.2",

--- a/src/main/config.js
+++ b/src/main/config.js
@@ -2,21 +2,27 @@ System.config({
   "baseURL": "/",
   "defaultJSExtensions": true,
   "transpiler": "babel",
+  "babelOptions": {
+    "optional": [
+      "runtime"
+    ]
+  },
   "paths": {
-    "github:*": "../../jspm_packages/github/*",
-    "npm:*": "../../jspm_packages/npm/*"
+    "github:*": "jspm_packages/github/*",
+    "npm:*": "jspm_packages/npm/*"
   }
 });
 
 System.config({
   "map": {
-    "js": "./target/js",
     "angular": "github:angular/bower-angular@1.4.2",
     "babel": "npm:babel-core@5.6.17",
     "babel-core": "npm:babel-core@5.6.17",
     "babel-runtime": "npm:babel-runtime@5.6.17",
     "core-js": "npm:core-js@0.9.18",
     "css": "github:systemjs/plugin-css@0.1.13",
+    "traceur": "github:jmcriffey/bower-traceur@0.0.90",
+    "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.90",
     "github:jspm/nodelibs-process@0.1.1": {
       "process": "npm:process@0.10.1"
     },


### PR DESCRIPTION
1. jspm_packages needs to be inside the baseURL. The reason is that otherwise we can't know how to locate it on both client and server from the paths value in the config file. A value of `../../jspm_packages` will be dir-relative on the server, and page-relative on the client. Not baseURL-relative. Created https://github.com/jspm/jspm-cli/issues/925 to ensure this doesn't happen.
2. All map configs must locate to within paths or the baseURL. This is because bundling needs to create canonical names out of paths or baseURL references. Rather add a `builder.loader.config({ paths: { 'js/*': 'target/js'*' } })` in the builder if you really want paths of this form.
3. When loading a config file with a baseURL value of `/` this won't work on the server. What we do in jspm is load the config, alter the baseURL and then configure the builder loader. This is done for you if you just use `require('jspm').Builder`. This will be better documented in the 0.16 release as the API to do builds.
